### PR TITLE
only report max_created_at for never scheduled jobs

### DIFF
--- a/lib/queue_classic_plus/update_metrics.rb
+++ b/lib/queue_classic_plus/update_metrics.rb
@@ -18,7 +18,7 @@ module QueueClassicPlus
       {
         jobs_queued: jobs_queued,
         jobs_scheduled: jobs_scheduled,
-        max_created_at: max_age("created_at"),
+        max_created_at: max_age("created_at", "created_at = scheduled_at"),
         max_locked_at: max_age("locked_at", "locked_at IS NOT NULL"),
         "max_created_at.unlocked" => max_age("locked_at", "locked_at IS NULL"),
         "jobs_delayed.lag" => max_age("scheduled_at"),
@@ -60,11 +60,7 @@ module QueueClassicPlus
       conditions.unshift not_failed
       conditions.unshift "scheduled_at <= NOW()"
 
-      # This is to support `jobs_delayed.lag`. Basically, comparing the same column
-      # with itself to know max_age isn't helpful.
-      reference_time = column.to_s == 'created_at' ? 'scheduled_at' : 'now()'
-
-      q = "SELECT EXTRACT(EPOCH FROM #{reference_time} - #{column}) AS age_in_seconds
+      q = "SELECT EXTRACT(EPOCH FROM now() - #{column}) AS age_in_seconds
            FROM queue_classic_jobs
            WHERE #{conditions.join(" AND ")}
            ORDER BY age_in_seconds DESC

--- a/spec/update_metrics_spec.rb
+++ b/spec/update_metrics_spec.rb
@@ -87,7 +87,7 @@ describe QueueClassicPlus::UpdateMetrics do
           one_min_ago = 1.minute.ago
           QueueClassicJob.last.update(created_at: 2.minutes.ago, scheduled_at: one_min_ago)
           QueueClassicJob.first.update(created_at: one_min_ago, scheduled_at: one_min_ago)
-          expect(subject[:max_created_at]).to eq 60
+          expect(subject[:max_created_at]).to be_within(1).of(60)
         end
       end
     end

--- a/spec/update_metrics_spec.rb
+++ b/spec/update_metrics_spec.rb
@@ -80,11 +80,14 @@ describe QueueClassicPlus::UpdateMetrics do
           expect(0..0.2).to include(max)
         end
 
-        context 'after scheduled_at is passed' do
-          it 'reports time that the job has been ready' do
-            QueueClassicJob.last.update(created_at: 5.minutes.ago, scheduled_at: 1.minutes.ago)
-            expect(subject[:max_created_at]).to eq 240
-          end
+        it 'reports time only for jobs that were never scheduled for future' do
+          QueueClassicJob.delete_all
+          QC.enqueue 'puts'
+          QC.enqueue_in 1, 'puts'
+          one_min_ago = 1.minute.ago
+          QueueClassicJob.last.update(created_at: 2.minutes.ago, scheduled_at: one_min_ago)
+          QueueClassicJob.first.update(created_at: one_min_ago, scheduled_at: one_min_ago)
+          expect(subject[:max_created_at]).to eq 60
         end
       end
     end


### PR DESCRIPTION
Our alerting on that didn't make sense anymore. So, now, we basically have two metrics similar: `max_created_at` which reports the biggest lag to process jobs that were enqueued for immediate processing, and `jobs_delayed.lag` which reports biggest lag to process jobs that were enqueued for scheduling and that are now ready to be processed.

@smathieu @rainforestapp/devs 