### PR TITLE
Fix issue with Raven exception handling

### DIFF
--- a/lib/queue_classic_plus/tasks/work.rake
+++ b/lib/queue_classic_plus/tasks/work.rake
@@ -2,6 +2,15 @@ namespace :qc_plus do
   desc "Start a new worker for the (default or $QUEUE) queue"
   task :work  => :environment do
     puts "Starting up worker for queue #{ENV['QUEUE']}"
+
+    if defined? Raven
+      Raven.configure do |config|
+        # ActiveRecord::RecordNotFound is ignored by Raven by default,
+        # which shouldn't happen in background jobs.
+        config.excluded_exceptions = []
+      end
+    end
+
     @worker = QueueClassicPlus::CustomWorker.new
 
     trap('INT') do


### PR DESCRIPTION
Raven ignores ActiveRecord::RecordNotFound exceptions by default, which
is problematic in background processes. This is pretty hacky, but the
best way I could think of of dealing with the issue.

@rainforestapp/devs