### PR TITLE
Build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 before_script:
+  - gem update bundler
   - psql -c 'create database queue_classic_plus_test;' -U postgres
   - export QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_plus_test"
   - ruby -r queue_classic -e "QC::Setup.create"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: ruby
 before_script:
   - psql -c 'create database queue_classic_plus_test;' -U postgres
+  - export QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_plus_test"
+  - ruby -r queue_classic -e "QC::Setup.create"
+  - psql -U postgres -d queue_classic_plus_test -c 'ALTER TABLE queue_classic_jobs ADD COLUMN last_error TEXT'
+  - psql -U postgres -d queue_classic_plus_test -c 'ALTER TABLE queue_classic_jobs ADD COLUMN remaining_retries INTEGER'
 
 rvm:
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ before_install:
   - gem update bundler
 before_script:
   - psql -c 'create database queue_classic_plus_test;' -U postgres
-  - export QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_plus_test"
-  - ruby -r queue_classic -e "QC::Setup.create"
-  - psql -U postgres -d queue_classic_plus_test -c 'ALTER TABLE queue_classic_jobs ADD COLUMN last_error TEXT'
-  - psql -U postgres -d queue_classic_plus_test -c 'ALTER TABLE queue_classic_jobs ADD COLUMN remaining_retries INTEGER'
 
 rvm:
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_script:
-  - gem update bundler
+  - gem install bundler -v 1.9.10
   - psql -c 'create database queue_classic_plus_test;' -U postgres
   - export QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_plus_test"
   - ruby -r queue_classic -e "QC::Setup.create"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
+before_install:
+  - gem update bundler
 before_script:
-  - gem install bundler -v 1.9.10
   - psql -c 'create database queue_classic_plus_test;' -U postgres
   - export QC_DATABASE_URL="postgres://postgres@localhost/queue_classic_plus_test"
   - ruby -r queue_classic -e "QC::Setup.create"

--- a/spec/queue_classic/queue_spec.rb
+++ b/spec/queue_classic/queue_spec.rb
@@ -1,13 +1,16 @@
+require 'spec_helper'
+
 describe QC do
 
   describe ".lock" do
 
     context "lock" do
-      QC.enqueue_retry_in(1, "puts", 5, 2)
-      sleep 1
-      job = QC.lock
 
       it "should lock the job with remaining_retries" do
+        QC.enqueue_retry_in(1, "puts", 5, 2)
+        sleep 1
+        job = QC.lock
+
         expect(job[:q_name]).to eq("default")
         expect(job[:method]).to eq("puts")
         expect(job[:args][0]).to be(2)


### PR DESCRIPTION
Fixes #17

Updating bundle version to fix builds with ruby > 2.1 (see: https://github.com/rubygems/rubygems/issues/1419)

Fixed `queue_spec` by moving the QC call inside the test. This way the test db is created by the `spec_helper` before the test be executed.

@rainforestapp/core review please :smile: 