### PR TITLE
Force-retry jobs when connection is lost

### DIFF
--- a/lib/queue_classic_plus/inheritable_attr.rb
+++ b/lib/queue_classic_plus/inheritable_attr.rb
@@ -28,7 +28,7 @@ module QueueClassicPlus
       end
 
       def self.uncloneable
-        [Symbol, TrueClass, FalseClass, NilClass]
+        [Symbol, TrueClass, FalseClass, NilClass, Fixnum]
       end
     end
   end

--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -21,6 +21,7 @@ module Jobs
     class TestJobNoRetry < QueueClassicPlus::Base
       class Custom < RuntimeError
       end
+      disable_retries!
 
       @queue = :low
 


### PR DESCRIPTION
We already reconnect when the PG connection is lost mid-job, but the job
would normally get re-enqueued on the failed_jobs queue which isn't
ideal. Jobs should almost always be retried if the connection is lost. I
added a `disable_retries!` escape hatch for the rare occasion that
they're not.

See rainforestapp/Rainforest#7995

@rainforestapp/core @ukd1