### PR TITLE
RF-9 fix worker fails with PG::UnableToSend

### DIFF
--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -40,5 +40,21 @@ module Jobs
       end
     end
 
+    class Exception < RuntimeError
+      attr_reader :original_exception
+
+      def initialize(e)
+        @original_exception = e
+      end
+    end
+
+    class ConnectionReapedTestJob < QueueClassicPlus::Base
+      @queue = :low
+      retry! on: Exception, max: 5
+
+      def self.perform
+        raise Exception.new(PG::UnableToSend.new)
+      end
+    end
   end
 end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -65,38 +65,22 @@ describe QueueClassicPlus::CustomWorker do
       end
     end
 
-    [PG::UnableToSend, PG::ConnectionBad].each do |exception|
-      context "with a #{exception} exception" do
-        before do
-          original_execute = QC.default_conn_adapter.method(:execute)
-          allow(QC.default_conn_adapter).to receive(:execute) do |*args|
-            if args.first == 'ROLLBACK'
-              raise exception
-            else
-              original_execute.call(*args)
-            end
-          end
+    context 'when PG connection reaped during a job' do
+      before { Jobs::Tests::ConnectionReapedTestJob.enqueue_perform }
+
+      it 'retries without incrementing retries' do
+        Timecop.freeze do
+          worker.work
+          expect(failed_queue.count).to eq 0
+          QueueClassicMatchers::QueueClassicRspec.find_by_args('low', 'Jobs::Tests::ConnectionReapedTestJob._perform', []).first['remaining_retries'].should eq "5"
         end
+      end
 
-        it 'retries without incrementing retries' do
-          job_type.enqueue_perform(true)
-          Timecop.freeze do
-            worker.work
-            expect(failed_queue.count).to eq 0
-            QueueClassicMatchers::QueueClassicRspec.find_by_args('low', 'Jobs::Tests::LockedTestJob._perform', [true]).first['remaining_retries'].should eq "5"
-          end
-        end
-
-        context 'with retries disabled for the class' do
-          let(:job_type) { Jobs::Tests::TestJobNoRetry }
-
-          it 'enqueues the failed queue' do
-            job_type.enqueue_perform(true)
-            Timecop.freeze do
-              worker.work
-              expect(failed_queue.count).to eq 1
-            end
-          end
+      it 'ensures to rollback' do
+        allow(QC.default_conn_adapter).to receive(:execute).and_call_original
+        expect(QC.default_conn_adapter).to receive(:execute).with('ROLLBACK')
+        Timecop.freeze do
+          worker.work
         end
       end
     end


### PR DESCRIPTION
Fixes RF-9

@rainforestapp/core 

Please see the issue comments on why this solves the issue. This fix will:

- prevent worker to fail if connection reaped during processing a job
- ensure to execute `ROLLBACK`
- not hide original exception with PG::UnableToSend