### PR TITLE
RF-2803 Be more discriminate with PG error retries

### DIFF
--- a/spec/sample_jobs.rb
+++ b/spec/sample_jobs.rb
@@ -1,3 +1,5 @@
+require 'pg'
+
 class SomeException < RuntimeError
 end
 
@@ -54,6 +56,14 @@ module Jobs
 
       def self.perform
         raise Exception.new(PG::UnableToSend.new)
+      end
+    end
+
+    class UniqueViolationTestJob < QueueClassicPlus::Base
+      @queue = :low
+
+      def self.perform
+        raise Exception.new(PG::UniqueViolation.new)
       end
     end
   end

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -85,6 +85,17 @@ describe QueueClassicPlus::CustomWorker do
       end
     end
 
+    context 'with non-connection based PG jobs' do
+      before { Jobs::Tests::UniqueViolationTestJob.enqueue_perform }
+
+      it 'sends the job to the failed jobs queue' do
+        Timecop.freeze do
+          worker.work
+        end
+        expect(failed_queue.count).to eq 1
+      end
+    end
+
     context 'when retries have been exhausted' do
       before do
         job_type.max_retries = 0


### PR DESCRIPTION
We were retrying on *all* PG errors, which includes things like
constraint violations and other stuff that isn't retriable.