### PR TITLE
Remove Fixnum / Bignum if running > 2.4

### DIFF
--- a/lib/queue_classic_plus/inheritable_attr.rb
+++ b/lib/queue_classic_plus/inheritable_attr.rb
@@ -28,7 +28,7 @@ module QueueClassicPlus
       end
 
       def self.uncloneable
-        [Symbol, TrueClass, FalseClass, NilClass, Fixnum]
+        [Symbol, TrueClass, FalseClass, NilClass]
       end
     end
   end

--- a/lib/queue_classic_plus/inheritable_attr.rb
+++ b/lib/queue_classic_plus/inheritable_attr.rb
@@ -29,7 +29,7 @@ module QueueClassicPlus
 
       def self.uncloneable
         tmp = [Symbol, TrueClass, FalseClass, NilClass]
-        tmp << [Fixnum, Bignum] if RUBY_VERSION < '2.4.0'
+        tmp += [Fixnum, Bignum] if RUBY_VERSION < '2.4.0'
         tmp
       end
     end

--- a/lib/queue_classic_plus/inheritable_attr.rb
+++ b/lib/queue_classic_plus/inheritable_attr.rb
@@ -28,7 +28,9 @@ module QueueClassicPlus
       end
 
       def self.uncloneable
-        [Symbol, TrueClass, FalseClass, NilClass]
+        tmp = [Symbol, TrueClass, FalseClass, NilClass]
+        tmp << [Fixnum, Bignum] if RUBY_VERSION < '2.4.0'
+        tmp
       end
     end
   end


### PR DESCRIPTION
Solves:

```
/home/ubuntu/Rainforest/vendor/bundle/ruby/2.4.0/bundler/gems/queue_classic_plus-e4112e954132/lib/queue_classic_plus/inheritable_attr.rb:31: warning: constant ::Fixnum is deprecated
/home/ubuntu/Rainforest/vendor/bundle/ruby/2.4.0/bundler/gems/queue_classic_plus-e4112e954132/lib/queue_classic_plus/inheritable_attr.rb:31: warning: constant ::Fixnum is deprecated
/home/ubuntu/Rainforest/vendor/bundle/ruby/2.4.0/bundler/gems/queue_classic_plus-e4112e954132/lib/queue_classic_plus/inheritable_attr.rb:31: warning: constant ::Fixnum is deprecated
/home/ubuntu/Rainforest/vendor/bundle/ruby/2.4.0/bundler/gems/queue_classic_plus-e4112e954132/lib/queue_classic_plus/inheritable_attr.rb:31: warning: constant ::Fixnum is deprecated
```