### PR TITLE
RF-5843 Avoid infinite loop in force_retry and add more logging

### DIFF
--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -12,7 +12,7 @@ module QueueClassicPlus
     inheritable_attr :max_retries
     inheritable_attr :disable_retries
 
-    self.max_retries = 0
+    self.max_retries = 5
     self.retries_on = {}
     self.disable_retries = false
 
@@ -102,13 +102,13 @@ module QueueClassicPlus
     def self._perform(*args)
       Metrics.timing("qu_perform_time", source: librato_key) do
         if skip_transaction
-          perform *args
+          perform(*args)
         else
           transaction do
             # .to_i defaults to 0, which means no timeout in postgres
             timeout = ENV['POSTGRES_STATEMENT_TIMEOUT'].to_i * 1000
             execute "SET LOCAL statement_timeout = #{timeout}"
-            perform *args
+            perform(*args)
           end
         end
       end

--- a/lib/queue_classic_plus/queue_classic/queue.rb
+++ b/lib/queue_classic_plus/queue_classic/queue.rb
@@ -6,7 +6,7 @@ module QC
         s = "INSERT INTO #{TABLE_NAME} (q_name, method, args, scheduled_at, remaining_retries)
              VALUES ($1, $2, $3, now() + interval '#{seconds.to_i} seconds', $4)"
 
-        res = conn_adapter.execute(s, name, method, JSON.dump(args), remaining_retries)
+        conn_adapter.execute(s, name, method, JSON.dump(args), remaining_retries)
       end
     end
 

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -68,11 +68,11 @@ describe QueueClassicPlus::CustomWorker do
     context 'when PG connection reaped during a job' do
       before { Jobs::Tests::ConnectionReapedTestJob.enqueue_perform }
 
-      it 'retries without incrementing retries' do
+      it 'retries' do
         Timecop.freeze do
           worker.work
           expect(failed_queue.count).to eq 0
-          QueueClassicMatchers::QueueClassicRspec.find_by_args('low', 'Jobs::Tests::ConnectionReapedTestJob._perform', []).first['remaining_retries'].should eq "5"
+          QueueClassicMatchers::QueueClassicRspec.find_by_args('low', 'Jobs::Tests::ConnectionReapedTestJob._perform', []).first['remaining_retries'].should eq "4"
         end
       end
 


### PR DESCRIPTION
This PR adds the following

- Avoids `force_retry` infinite loop
- Adds Librato metrics for `retry` and `force_try`