### PR TITLE
Rewrite NewRelic extension to use Module.prepend rather than the deprecated alias_method_chain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+services:
+  - postgresql
 before_install:
   - gem update bundler
 install: bundle install --without development

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'timecop'
+  gem 'newrelic_rpm'
 end

--- a/lib/queue_classic_plus/new_relic.rb
+++ b/lib/queue_classic_plus/new_relic.rb
@@ -1,30 +1,29 @@
 require 'new_relic/agent/method_tracer'
 
-QueueClassicPlus::Base.class_eval do
-  class << self
-    include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+module QueueClassicNewRelic
+  include NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
-    def new_relic_key
-      "Custom/QueueClassicPlus/#{librato_key}"
-    end
-
-    def _perform_with_new_relic(*args)
-      opts = {
-        name: 'perform',
-        class_name: self.name,
-        category: 'OtherTransaction/QueueClassicPlus',
-      }
-
-      perform_action_with_newrelic_trace(opts) do
-        if NewRelic::Agent.config[:'queue_classic_plus.capture_params']
-          NewRelic::Agent.add_custom_parameters(job_arguments: args)
-        end
-        _perform_without_new_relic *args
-      end
-    end
-
-    alias_method_chain :_perform, :new_relic
+  def new_relic_key
+    "Custom/QueueClassicPlus/#{librato_key}"
   end
+
+  def _perform(*args)
+    opts = {
+      name: 'perform',
+      class_name: self.name,
+      category: 'OtherTransaction/QueueClassicPlus',
+    }
+
+    perform_action_with_newrelic_trace(opts) do
+      if NewRelic::Agent.config[:'queue_classic_plus.capture_params']
+        NewRelic::Agent.add_custom_parameters(job_arguments: args)
+      end
+
+      super
+    end
+  end
+
+  QueueClassicPlus::Base.singleton_class.send(:prepend, QueueClassicNewRelic)
 end
 
 QueueClassicPlus::CustomWorker.class_eval do

--- a/queue_classic_plus.gemspec
+++ b/queue_classic_plus.gemspec
@@ -19,6 +19,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "queue_classic", ">= 3.1.0"
-  spec.add_development_dependency "bundler", "~> 1.6"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
+    spec.add_development_dependency "bundler", "~> 1.6"
+  else
+    spec.add_development_dependency "bundler", "~> 2.0"
+  end
   spec.add_development_dependency "rake"
 end

--- a/spec/new_relic_spec.rb
+++ b/spec/new_relic_spec.rb
@@ -1,0 +1,26 @@
+describe 'requiring queue_classic_plus/new_relic' do
+  subject do
+    Class.new(QueueClassicPlus::Base) do
+      @queue = :test
+
+      def self.perform
+      end
+
+      def self.name
+        'Funky::Name'
+      end
+    end
+  end
+
+  it 'adds NewRelic profiling support' do
+    expect(subject).to receive(:perform_action_with_newrelic_trace).once.with({
+      name: 'perform',
+      class_name: 'Funky::Name',
+      category: 'OtherTransaction/QueueClassicPlus',
+    })
+
+    subject._perform
+    require 'queue_classic_plus/new_relic'
+    subject._perform
+  end
+end


### PR DESCRIPTION
See https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/
and https://sikac.hu/how-to-use-module-prepend-to-override-class-method-in-ruby-4197c6159cd3