### PR TITLE
[RF-21797] Unexclude exceptions for Sentry 4 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you want to log exceptions in your favorite exception tracker. You can config
 
 ```ruby
 QueueClassicPlus.exception_handler = -> (exception, job) do
-  Raven.capture_exception(exception, extra: {job: job, env: ENV})
+  Sentry.capture_exception(exception, extra: { job: job, env: ENV })
 end
 ```
 

--- a/lib/queue_classic_plus/tasks/work.rake
+++ b/lib/queue_classic_plus/tasks/work.rake
@@ -3,10 +3,14 @@ namespace :qc_plus do
   task :work  => :environment do
     puts "Starting up worker for queue #{ENV['QUEUE']}"
 
-    if defined? Raven
+    # ActiveRecord::RecordNotFound is ignored by Sentry by default,
+    # which shouldn't happen in background jobs.
+    if defined?(Sentry)
+      Sentry.init do |config|
+        config.excluded_exceptions = []
+      end
+    elsif defined?(Raven)
       Raven.configure do |config|
-        # ActiveRecord::RecordNotFound is ignored by Raven by default,
-        # which shouldn't happen in background jobs.
         config.excluded_exceptions = []
       end
     end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = "4.0.0.alpha4"
+  VERSION = "4.0.0.alpha5"
 end


### PR DESCRIPTION
Do what we did for Sentry 3 (`Raven`) for Sentry 4 as well (`Sentry`)