### PR TITLE
Use ActiveJob's (de)serialization when Rails is defined

### DIFF
--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = "4.0.0.alpha5"
+  VERSION = "4.0.0.alpha6"
 end

--- a/queue_classic_plus.gemspec
+++ b/queue_classic_plus.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   end
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activerecord", "~> 6.0"
+  spec.add_development_dependency "activejob"
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -159,6 +159,33 @@ describe QueueClassicPlus::Base do
         expect(subject.max_retries).to eq(5)
       end
     end
+
+    context "with Rails defined" do
+      require 'active_job/arguments'
+
+      before { stub_const('Rails', true) }
+
+      subject do
+        Class.new(QueueClassicPlus::Base) do
+          @queue = :test
+
+          def self.perform(foo, bar)
+          end
+        end
+      end
+
+      it "serializes parameters when enqueuing a job" do
+        expect(ActiveJob::Arguments).to receive(:serialize).with([42, true])
+
+        subject.do(42, true)
+      end
+
+      it "deserializes parameters when performing an enqueued job" do
+        expect(ActiveJob::Arguments).to receive(:deserialize).with([42, true]) { [42, true] }
+
+        subject._perform(42, true)
+      end
+    end
   end
 
   describe ".librato_key" do


### PR DESCRIPTION
The specs are written the way they are because I couldn't get `ActiveJob::Arguments.serialize` and `.deserialize` to work with just ActiveJob loaded, and I felt like requiring all of Rails, just for this one test, was overkill.