### PR TITLE
[RF-21864] Continue sending events to Sentry synchronously after Sentry 4.1 update

### DIFF
--- a/lib/queue_classic_plus/tasks/work.rake
+++ b/lib/queue_classic_plus/tasks/work.rake
@@ -8,6 +8,7 @@ namespace :qc_plus do
     if defined?(Sentry)
       Sentry.init do |config|
         config.excluded_exceptions = []
+        config.background_worker_threads = 0 if Gem::Version.new(Sentry::VERSION) >= Gem::Version.new('4.1.0')
       end
     elsif defined?(Raven)
       Raven.configure do |config|

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = "4.0.0.alpha6"
+  VERSION = "4.0.0.alpha7"
 end


### PR DESCRIPTION
Sentry [switched to asynchronous event sending](https://github.com/getsentry/sentry-ruby/blob/0e268090667d226120b33955d7a535ceab8e696a/sentry-ruby/CHANGELOG.md#events-are-sent-asynchronously) in v4.1.0. This causes events to not be sent by QC (similar to the issue raised in https://github.com/getsentry/sentry-ruby/issues/1324).