### PR TITLE
RF-26342 Support ruby 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.2.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -27,7 +27,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.0.3
+      - image: cimg/ruby:3.2.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,3 +65,4 @@ workflows:
                 - /^v.*/
           context:
             - DockerHub
+            - RubyGems

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ tmp
 mkmf.log
 tags
 .project
-.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tmp
 mkmf.log
 tags
 .project
+.tool-versions

--- a/lib/queue_classic_plus/datadog.rb
+++ b/lib/queue_classic_plus/datadog.rb
@@ -2,7 +2,7 @@
 
 module QueueClassicDatadog
   def _perform(*args)
-    Datadog.tracer.trace('qc.job', service_name: 'qc.job', resource: "#{name}#perform") do |_|
+    Datadog::Tracing.trace('qc.job', service: 'qc.job', resource: "#{name}#perform") do |_|
       super
     end
   end

--- a/lib/queue_classic_plus/datadog.rb
+++ b/lib/queue_classic_plus/datadog.rb
@@ -2,8 +2,14 @@
 
 module QueueClassicDatadog
   def _perform(*args)
-    Datadog::Tracing.trace('qc.job', service: 'qc.job', resource: "#{name}#perform") do |_|
-      super
+    if Gem.loaded_specs['ddtrace'].version >= Gem::Version.new('1')
+      Datadog::Tracing.trace('qc.job', service: 'qc.job', resource: "#{name}#perform") do |_|
+        super
+      end
+    else
+      Datadog.tracer.trace('qc.job', service_name: 'qc.job', resource: "#{name}#perform") do |_|
+        super
+      end
     end
   end
 

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -10,8 +10,8 @@ describe 'requiring queue_classic_plus/new_relic' do
 
   it 'adds Datadog profiling support' do
     require 'queue_classic_plus/datadog'
-    expect(Datadog.tracer).to receive(:trace).with(
-      'qc.job', service_name: 'qc.job', resource: 'FunkyName#perform'
+    expect(Datadog::Tracing).to receive(:trace).with(
+      'qc.job', service: 'qc.job', resource: 'FunkyName#perform'
     )
     subject
   end


### PR DESCRIPTION
* Update to support Ruby 3.2.0
* Support both major versions for Datadog's gem `ddtrace`: 0.x and 1.x. 
* Make use of the newer major version Datadog gem API. See [link](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md#removed-datadogtracer): 
  > Removed `Datadog.tracer`
Many of the functions accessed directly through Datadog.tracer have been moved to Datadog::Tracing instead.

**NOTE:** We may still have to test the alerts/metrics manually to see if they are being directed to the correct place with the new version. Any thoughts on how to test that or who can help me with it?