### PR TITLE
[RF-29783] Add configuration for Datadog service name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 gem "queue_classic_matchers", github: 'rainforestapp/queue_classic_matchers'
 gem 'pry'
+gem 'dry-configurable'
 
 group :development do
   gem "guard-rspec", require: false

--- a/lib/queue_classic_plus/datadog.rb
+++ b/lib/queue_classic_plus/datadog.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+require 'dry-configurable'
+
 module QueueClassicDatadog
+  extend Dry::Configurable
+
+  setting :dd_service
+
   def _perform(*args)
+    service_name = QueueClassicDatadog.config.dd_service || 'qc.job'
+
     if Gem.loaded_specs['ddtrace'].version >= Gem::Version.new('1')
-      Datadog::Tracing.trace('qc.job', service: 'qc.job', resource: "#{name}#perform") do |_|
+      Datadog::Tracing.trace('qc.job', service: service_name, resource: "#{name}#perform") do |_|
         super
       end
     else

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -15,4 +15,18 @@ describe 'requiring queue_classic_plus/new_relic' do
     )
     subject
   end
+
+  context "when service name is configured" do
+    let(:configured_service_name) { "configured_service_name" }
+
+    it "traces using the service name" do
+      require 'queue_classic_plus/datadog'
+      QueueClassicDatadog.config.dd_service = configured_service_name
+
+      expect(Datadog::Tracing).to receive(:trace).with(
+        'qc.job', service: configured_service_name, resource: 'FunkyName#perform'
+      )
+      subject
+    end
+  end
 end


### PR DESCRIPTION
If a Datadog service name is configured, use that when tracing. If it is not, continue to use the default qc.job.

Uses the `dry-configurable` gem. https://dry-rb.org/gems/dry-configurable/1.0/

Once this is shipped, we can configure our apps to give QC jobs the desired service name like this:

```
# config/initializers/queue_classic.rb
QueueClassicDatadog.config.dd_service = "desired service name"
```

Would be nice to have a proper Datadog integration so we could do:
```
Datadog.configure do |config|
  config.tracing.instrument :queue_classic_plus, service_name: "rainforest-qc"
```
but I'm not sure what's involved in that and the implementation I've gone for is probably the simplest.