### PR TITLE
[RF-29881] Add dry-configurable dependency

### DIFF
--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha12'.freeze
+  VERSION = '4.0.0.alpha13'.freeze
 end

--- a/queue_classic_plus.gemspec
+++ b/queue_classic_plus.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "queue_classic", "4.0.0.pre.alpha1"
+  spec.add_dependency "dry-configurable", "1.1.0"
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
     spec.add_development_dependency "bundler", "~> 1.6"
   else


### PR DESCRIPTION
While pulling the `alpha12` version of this gem, I noticed the new dependency was not being installed. I think this is because the dependency was not added to the `gemspec` file.

Also incremented the version here to `alpha13` to make re-releasing easier (we don't have to rollback `alpha12`.)