### PR TITLE
Update Datadog service name documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 
 ## Advanced configuration
 
-If you want to log exceptions in your favorite exception tracker. You can configured it like sso:
+If you want to log exceptions in your favorite exception tracker. You can configured it like so:
 
 ```ruby
 QueueClassicPlus.exception_handler = -> (exception, job) do
@@ -142,18 +142,24 @@ Push metrics to your metric provider (only Librato is supported for now).
 QueueClassicPlus.update_metrics
 ```
 
-Call this is a cron job or something similar.
+Call this in a cron job or something similar.
 
-If you are using NewRelic and want to push performance data to it, you can add this to an initializer:
+If you are using New Relic and want to push performance data to it, you can add this to an initializer:
 
 ```ruby
 require "queue_classic_plus/new_relic"
 ```
 
-To instrument DataDog monitoring add this to your QC initializer:
+To instrument Datadog monitoring add this to your QC initializer:
 
 ```ruby
 require "queue_classic_plus/datadog"
+```
+
+The Datadog service name defaults to `qc.job`. This can be changed in the initializer: 
+
+```ruby
+QueueClassicDatadog.config.dd_service = "custom_service_name"
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -178,4 +178,7 @@ createdb queue_classic_plus_test
 
 ## Releasing
 
-Releasing is done in CircleCI via the `push_to_rubygems`, triggered by pushing a tagged commit. To do so, simply [create a new GitHub release](https://github.com/rainforestapp/queue_classic_plus/releases/new).
+Releasing is done in CircleCI via the `push_to_rubygems`, triggered by pushing a tagged commit.
+You can create a new `tag` while [creating a new GitHub release](https://github.com/rainforestapp/queue_classic_plus/releases/new).
+
+_** Note: The `tag` is what publishes a new version of the gem. The `release` is purely for documentation._


### PR DESCRIPTION
Adds documentation for how to configure Datadog service name for feature added in https://github.com/rainforestapp/queue_classic_plus/releases/tag/v4.0.0.alpha12

Also clarified documentation for gem publishing process.