### PR TITLE
[RF-29953] Fix thread safe enqueueing

### DIFF
--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -79,13 +79,19 @@ module QueueClassicPlus
     end
 
     def self.enqueue(method, *args)
-      conn = QC.default_conn_adapter.connection
-      conn.transaction do
-        conn.exec("SELECT pg_advisory_xact_lock(#{queue_name_digest})")
-        if can_enqueue?(method, *args)
-          queue.enqueue(method, *serialized(args))
-        end
-      end
+       conn = QC.default_conn_adapter.connection
+       check_and_enqueue = proc do
+         conn.exec("SELECT pg_advisory_xact_lock(#{queue_name_digest})")
+         if can_enqueue?(method, *args)
+           queue.enqueue(method, *serialized(args))
+         end
+       end
+
+       if [PG::PQTRANS_ACTIVE, PG::PQTRANS_INTRANS].include?(conn.transaction_status)
+         check_and_enqueue.call
+       else
+         conn.transaction &check_and_enqueue
+       end
     end
 
     def self.enqueue_perform(*args)

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha14'.freeze
+  VERSION = '4.0.0.alpha15'.freeze
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -44,6 +44,23 @@ describe QueueClassicPlus::Base do
       end
     end
 
+    context "when in a transaction" do
+      subject do
+        Class.new(QueueClassicPlus::Base) do
+          @queue = :test
+          lock!
+        end
+      end
+
+      it "does not create another transaction when enqueueing" do
+        conn = QC.default_conn_adapter.connection
+        expect(conn).to receive(:transaction).exactly(1).times.and_call_original
+        conn.transaction do
+          subject.do
+        end
+      end
+    end
+
     context "with default settings" do
       subject do
         Class.new(QueueClassicPlus::Base) do


### PR DESCRIPTION
https://github.com/rainforestapp/queue_classic_plus/pull/56 made `lock!` thread safe, but it fails if `enqueue` is called while already in a transaction, because it creates a nested one.

First check if there is already a transaction before creating one.