### PR TITLE
[RF-29953] Fix queue_name_digest going out of range

### DIFF
--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -2,12 +2,16 @@ module QueueClassicPlus
   class Base
     extend QueueClassicPlus::InheritableAttribute
 
+    # Max value for bigint calculated from
+    # https://stackoverflow.com/questions/28960478/postgres-maximum-value-for-bigint
+    PG_BIGINT_MAX = 9223372036854775807.freeze
+
     def self.queue
       QC::Queue.new(@queue)
     end
 
     def self.queue_name_digest
-      @queue_name_digest ||= @queue.to_s.to_i(36)
+      @queue_name_digest ||= @queue.to_s.to_i(36) % PG_BIGINT_MAX
     end
 
     inheritable_attr :locked

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha15'.freeze
+  VERSION = '4.0.0.alpha16'.freeze
 end


### PR DESCRIPTION
https://github.com/rainforestapp/queue_classic_plus/pull/56 added a semaphore for thread safety. It uses a digest created from the queue name as a key for `pg_advisory_xact_lock` so the semaphore works on a per queue basis.

However, the digest can sometimes go out of range of postgres `bigint`.

Adding a `modulo` on the digest to prevent this.
While this opens up the possibility of key clashes, it is extremely unlikely.

This bug showed up here: https://app.circleci.com/pipelines/github/rainforestapp/Rainforest/36696/workflows/8442de01-be71-4c6c-8918-1e41f13784ba/jobs/355430/tests

I've tested the fix against the main app and it works.