### PR TITLE
[RF-29953] Add conditional constraint on lock jobs

### DIFF
--- a/lib/queue_classic_plus.rb
+++ b/lib/queue_classic_plus.rb
@@ -15,14 +15,18 @@ module QueueClassicPlus
 
   def self.migrate(c = QC::default_conn_adapter.connection)
     conn = QC::ConnAdapter.new(connection: c)
-    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN last_error TEXT")
-    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN remaining_retries INTEGER")
+    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS last_error TEXT")
+    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS remaining_retries INTEGER")
+    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS lock BOOLEAN NOT NULL DEFAULT FALSE")
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS index_queue_classic_jobs_enqueue_lock on queue_classic_jobs(q_name, method, args) WHERE lock IS TRUE")
   end
 
   def self.demigrate(c = QC::default_conn_adapter.connection)
     conn = QC::ConnAdapter.new(connection: c)
-    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN last_error")
-    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN remaining_retries")
+    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS last_error")
+    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS remaining_retries")
+    conn.execute("DROP INDEX IF EXISTS index_queue_classic_jobs_enqueue_lock")
+    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS lock")
   end
 
   def self.exception_handler

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha16'.freeze
+  VERSION = '4.0.0.alpha17'.freeze
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -3,6 +3,24 @@ require 'active_record'
 
 describe QueueClassicPlus::Base do
   context "A child of QueueClassicPlus::Base" do
+    subject do
+      Class.new(QueueClassicPlus::Base) do
+        @queue = :test
+      end
+    end
+
+    it "allows multiple enqueues" do
+      threads = []
+      50.times do
+        threads << Thread.new do
+          subject.do
+        end
+      end
+      threads.each(&:join)
+
+      expect(subject).to have_queue_size_of(50)
+    end
+
     context "that is locked" do
       subject do
         Class.new(QueueClassicPlus::Base) do
@@ -19,8 +37,21 @@ describe QueueClassicPlus::Base do
             expect(subject).to have_queue_size_of(1)
           end
         end
-
         threads.each(&:join)
+      end
+
+      it "allows enqueueing same job with different arguments" do\
+        threads = []
+        (1..3).each do |arg|
+          50.times do
+            threads << Thread.new do
+              subject.do(arg)
+            end
+          end
+        end
+        threads.each(&:join)
+
+        expect(subject).to have_queue_size_of(3)
       end
 
       it "checks for an existing job using the same serializing as job enqueuing" do
@@ -33,14 +64,6 @@ describe QueueClassicPlus::Base do
         subject.do(date)
         subject.do(date)
         expect(subject).to have_queue_size_of(1)
-      end
-
-      it "does allow multiple enqueues if something got locked for too long" do
-        subject.do
-        one_day_ago = Time.now - 60*60*24
-        execute "UPDATE queue_classic_jobs SET locked_at = '#{one_day_ago}' WHERE q_name = 'test'"
-        subject.do
-        expect(subject).to have_queue_size_of(2)
       end
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -11,14 +11,14 @@ describe QueueClassicPlus::Base do
 
     it "allows multiple enqueues" do
       threads = []
-      50.times do
+      10.times do
         threads << Thread.new do
           subject.do
         end
       end
       threads.each(&:join)
 
-      expect(subject).to have_queue_size_of(50)
+      expect(subject).to have_queue_size_of(10)
     end
 
     context "that is locked" do
@@ -31,7 +31,7 @@ describe QueueClassicPlus::Base do
 
       it "does not allow multiple enqueues" do
         threads = []
-        50.times do
+        10.times do
           threads << Thread.new do
             subject.do
             expect(subject).to have_queue_size_of(1)
@@ -40,10 +40,10 @@ describe QueueClassicPlus::Base do
         threads.each(&:join)
       end
 
-      it "allows enqueueing same job with different arguments" do\
+      it "allows enqueueing same job with different arguments" do
         threads = []
         (1..3).each do |arg|
-          50.times do
+          10.times do
             threads << Thread.new do
               subject.do(arg)
             end


### PR DESCRIPTION
The last attempt to make `lock!` threadsafe (https://github.com/rainforestapp/queue_classic_plus/pull/56) caused some major performance issues, because the lock key was on the  queue name, which means everything that wanted to enqueue something had to wait its turn to get a lock. And since the lock was on the transaction level, each turn also took the length of its transaction.

One solution I considered was reducing the scope of the lock key to specifically the (`q_name`, `job_name`, `arguments`). This would reduce the amount of locking significantly and probably would work. But it still has complications with transactions, like whether or not the `enqueue` is called from within a parent transaction or not and many locks being requested on the same transaction.

So I settled on this solution which I think is the simplest and most performant.
1. Add `lock` field to the queue table, indicating whether or not the job is `lock!`.
2. Add a conditional `unique constraint` on (`q_name`, `method`, `args`) if `lock` is `true`.
3. When inserting, do nothing if there is a `conflict`. This is consistent with current behaviour where we don't enqueue if there is already an instance of a `lock!` job.

This should make things faster than before as `ON CONFLICT DO NOTHING` happens at the DB level and we don't need an extra query to check enqueueability at the application level.

It works whether or not we are in a transaction.

The tradeoff is it no longer supports `QUEUE_CLASSIC_MAX_LOCK_TIME` where we would allow enqueueing another instance of a `lock!` job if the current instance has been running for over X minutes. We can't pass this criterion to the constraint at runtime, so we'd have to hardcode this threshold in the constraint.

But I think this was a dubious feature. If a job is `lock!` it must be for a reason, and having a second instance enqueued can cause unexpected (and surprising) problems. If a job is taking too long, we should kill it/rerun it/investigate.

In our main app, this env var isn't even set, so it was defaulting to 10 minutes, which I think is rather dangerous.