### PR TITLE
[RF-30285] Add QC job callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,8 @@ Jobs support the following callbacks:
 ```
 before_enqueue
 after_enqueue
-around_enqueue
 before_perform
 after_perform
-around_perform
 ```
 
 - `enqueue` callbacks are called when the job is initially enqueued, but not on retries.

--- a/README.md
+++ b/README.md
@@ -135,8 +135,11 @@ before_perform
 after_perform
 ```
 
-- `enqueue` callbacks are called when the job is initially enqueued, but not on retries.
-- `perform` callbacks are called when the job is picked up and run by a worker, including retries.
+- `enqueue` callbacks are called when the job is initially enqueued. Caveats:
+  - not called on retries
+  - not called when scheduled in the future (i.e. `Job.enqueue_perform_in`)
+  - still called if enqueuing fails because a job with `lock!` is already enqueued. 
+- `perform` callbacks are called any time the job is picked up and run by a worker, including retries and jobs scheduled in the future.
 
 Callbacks can either be implemented by providing a method to be called:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,58 @@ class Jobs::NoTransaction < QueueClassicPlus::Base
 end
 ```
 
+
+#### Callbacks
+
+Jobs support the following callbacks:
+```
+before_enqueue
+after_enqueue
+around_enqueue
+before_perform
+after_perform
+around_perform
+```
+
+- `enqueue` callbacks are called when the job is initially enqueued, but not on retries.
+- `perform` callbacks are called when the job is picked up and run by a worker, including retries.
+
+Callbacks can either be implemented by providing a method to be called:
+
+```ruby
+class Jobs::WithCallbackMethods < QueueClassicPlus::Base
+  before_enqueue :before_enqueue_method
+
+  @queue = :low
+
+  def self.before_enqueue_method(*args)
+    # ...
+  end
+
+  def self.perform(user_id)
+    # ...
+  end
+end
+```
+
+or by providing a block:
+
+```ruby
+class Jobs::WithCallbackBlocks < QueueClassicPlus::Base
+  before_enqueue do |*args|
+    # ...
+  end
+
+  @queue = :low
+
+  def self.perform(user_id)
+    # ...
+  end
+end
+```
+
+The `args` passed to the callback method/block will be the same as the arguments passed to `QueueClassicPlus::Base.do` and `QueueClassicPlus::Base.perform`. 
+
 ## Advanced configuration
 
 If you want to log exceptions in your favorite exception tracker. You can configured it like so:

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -182,12 +182,12 @@ module QueueClassicPlus
       QC.default_conn_adapter.execute(sql, *args)
     end
 
-    def self.define_callback(wrapped_method, type, callback_method, &_block)
+    def self.define_callback(name, type, callback_method, &_block)
       singleton_class.prepend(
         Module.new do |callback_module|
-          callback_module.define_method(wrapped_method) do |*args|
+          callback_module.define_method(name) do |*args|
             callback_args = args
-              if wrapped_method == :enqueue
+              if name == :enqueue
                 callback_args = callback_args.drop(1) # Class/method is the first argument. Callbacks don't need that.
               end
 

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -136,27 +136,27 @@ module QueueClassicPlus
       end
     end
 
-    def self.qc_before_enqueue(callback_method = nil, &block)
+    def self.before_enqueue(callback_method = nil, &block)
       define_callback(:enqueue, :before, callback_method, &block)
     end
 
-    def self.qc_after_enqueue(callback_method = nil, &block)
+    def self.after_enqueue(callback_method = nil, &block)
       define_callback(:enqueue, :after, callback_method, &block)
     end
 
-    def self.qc_around_enqueue(callback_method = nil, &block)
+    def self.around_enqueue(callback_method = nil, &block)
       define_callback(:enqueue, :around, callback_method, &block)
     end
 
-    def self.qc_before_perform(callback_method = nil, &block)
+    def self.before_perform(callback_method = nil, &block)
       define_callback(:perform, :before, callback_method, &block)
     end
 
-    def self.qc_after_perform(callback_method = nil, &block)
+    def self.after_perform(callback_method = nil, &block)
       define_callback(:perform, :after, callback_method, &block)
     end
 
-    def self.qc_around_perform(callback_method = nil, &block)
+    def self.around_perform(callback_method = nil, &block)
       define_callback(:perform, :around, callback_method, &block)
     end
 

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -144,20 +144,12 @@ module QueueClassicPlus
       define_callback(:enqueue, :after, callback_method, &block)
     end
 
-    def self.around_enqueue(callback_method = nil, &block)
-      define_callback(:enqueue, :around, callback_method, &block)
-    end
-
     def self.before_perform(callback_method = nil, &block)
       define_callback(:perform, :before, callback_method, &block)
     end
 
     def self.after_perform(callback_method = nil, &block)
       define_callback(:perform, :after, callback_method, &block)
-    end
-
-    def self.around_perform(callback_method = nil, &block)
-      define_callback(:perform, :around, callback_method, &block)
     end
 
     # Debugging
@@ -199,11 +191,11 @@ module QueueClassicPlus
           callback_args = callback_args.drop(1) # Class/method is the first argument. Callbacks don't need that.
         end
 
-        if [:before, :around].include?(type)
+        if type == :before
           block_given? ? yield(*callback_args) : send(callback_method, *callback_args)
         end
         super(*args)
-        if [:after, :around].include?(type)
+        if type == :after
           block_given? ? yield(*callback_args) : send(callback_method, *callback_args)
         end
       end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha18'.freeze
+  VERSION = '4.0.0.alpha19'.freeze
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -289,15 +289,7 @@ describe QueueClassicPlus::Base do
             class_variable_get(:@@block_result).append("around_perform_block")
           end
 
-          def self.before_enqueue_method(*_args); end;
-          def self.after_enqueue_method(*_args); end;
-          def self.around_enqueue_method(*_args); end;
-          def self.before_perform_method(*_args); end;
-          def self.after_perform_method(*_args); end;
-          def self.around_perform_method(*_args); end;
-
           def self.perform; end;
-
         end
       end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -259,6 +259,37 @@ describe QueueClassicPlus::Base do
 
           subject.perform
         end
+
+        context "when perform fails" do
+          subject do
+            Class.new(QueueClassicPlus::Base) do
+              @queue = :test
+
+              before_perform :before_perform_method
+              after_perform :after_perform_method
+              around_perform :around_perform_method
+
+              def self.before_perform_method(*_args); end;
+              def self.after_perform_method(*_args); end;
+              def self.around_perform_method(*_args); end;
+
+              def self.perform(*_args)
+                raise StandardError
+              end
+            end
+          end
+
+          it "does not call after callbacks" do
+            expect(subject).to receive(:before_perform_method).once
+            expect(subject).to_not receive(:after_perform_method)
+            expect(subject).to receive(:around_perform_method).once
+
+            begin
+              subject.perform
+            rescue StandardError
+            end
+          end
+        end
       end
 
       context "when callback defined multiple times" do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -261,6 +261,31 @@ describe QueueClassicPlus::Base do
         end
       end
 
+      context "when callback defined multiple times" do
+        subject do
+          Class.new(QueueClassicPlus::Base) do
+            @queue = :test
+
+            before_enqueue :before_enqueue_method_1
+            before_enqueue :before_enqueue_method_2
+            before_enqueue :before_enqueue_method_3
+
+            def self.before_enqueue_method_1(*_args); end;
+            def self.before_enqueue_method_2(*_args); end;
+            def self.before_enqueue_method_3(*_args); end;
+
+            def self.perform(*_args); end;
+          end
+        end
+
+        it "calls each callback" do
+          expect(subject).to receive(:before_enqueue_method_1).once
+          expect(subject).to receive(:before_enqueue_method_2).once
+          expect(subject).to receive(:before_enqueue_method_3).once
+
+          subject.do
+        end
+      end
     end
 
     context "with callback blocks defined" do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -192,18 +192,14 @@ describe QueueClassicPlus::Base do
 
           before_enqueue :before_enqueue_method
           after_enqueue :after_enqueue_method
-          around_enqueue :around_enqueue_method
 
           before_perform :before_perform_method
           after_perform :after_perform_method
-          around_perform :around_perform_method
 
           def self.before_enqueue_method(*_args); end;
           def self.after_enqueue_method(*_args); end;
-          def self.around_enqueue_method(*_args); end;
           def self.before_perform_method(*_args); end;
           def self.after_perform_method(*_args); end;
-          def self.around_perform_method(*_args); end;
 
           def self.perform(*_args); end;
         end
@@ -212,7 +208,6 @@ describe QueueClassicPlus::Base do
       it "passes enqueue arguments to callbacks" do
         expect(subject).to receive(:before_enqueue_method).with("enqueue_argument").once
         expect(subject).to receive(:after_enqueue_method).with("enqueue_argument").once
-        expect(subject).to receive(:around_enqueue_method).with("enqueue_argument").exactly(2).times
 
         subject.do("enqueue_argument")
       end
@@ -220,7 +215,6 @@ describe QueueClassicPlus::Base do
       it "passes perform arguments to callbacks" do
         expect(subject).to receive(:before_perform_method).with("perform_argument").once
         expect(subject).to receive(:after_perform_method).with("perform_argument").once
-        expect(subject).to receive(:around_perform_method).with("perform_argument").exactly(2).times
 
         subject.perform("perform_argument")
       end
@@ -229,7 +223,6 @@ describe QueueClassicPlus::Base do
         it "calls the enqueue callback methods" do
           expect(subject).to receive(:before_enqueue_method).once
           expect(subject).to receive(:after_enqueue_method).once
-          expect(subject).to receive(:around_enqueue_method).exactly(2).times
 
           subject.do
         end
@@ -237,7 +230,6 @@ describe QueueClassicPlus::Base do
         it "does not call the perform callbacks" do
           expect(subject).to_not receive(:before_perform_method)
           expect(subject).to_not receive(:after_perform_method)
-          expect(subject).to_not receive(:around_perform_method)
 
           subject.do
         end
@@ -247,7 +239,6 @@ describe QueueClassicPlus::Base do
         it "calls the perform callback methods" do
           expect(subject).to receive(:before_perform_method).once
           expect(subject).to receive(:after_perform_method).once
-          expect(subject).to receive(:around_perform_method).exactly(2).times
 
           subject.perform
         end
@@ -255,7 +246,6 @@ describe QueueClassicPlus::Base do
         it "does not call the enqueue callbacks" do
           expect(subject).to_not receive(:before_enqueue_method)
           expect(subject).to_not receive(:after_enqueue_method)
-          expect(subject).to_not receive(:around_enqueue_method)
 
           subject.perform
         end
@@ -267,11 +257,9 @@ describe QueueClassicPlus::Base do
 
               before_perform :before_perform_method
               after_perform :after_perform_method
-              around_perform :around_perform_method
 
               def self.before_perform_method(*_args); end;
               def self.after_perform_method(*_args); end;
-              def self.around_perform_method(*_args); end;
 
               def self.perform(*_args)
                 raise StandardError
@@ -282,7 +270,6 @@ describe QueueClassicPlus::Base do
           it "does not call after callbacks" do
             expect(subject).to receive(:before_perform_method).once
             expect(subject).to_not receive(:after_perform_method)
-            expect(subject).to receive(:around_perform_method).once
 
             begin
               subject.perform
@@ -331,18 +318,12 @@ describe QueueClassicPlus::Base do
           after_enqueue do |*_args|
             class_variable_get(:@@block_result).append("after_enqueue_block")
           end
-          around_enqueue do |*_args|
-            class_variable_get(:@@block_result).append("around_enqueue_block")
-          end
 
           before_perform do |*_args|
             class_variable_get(:@@block_result).append("before_perform_block")
           end
           after_perform do |*_args|
             class_variable_get(:@@block_result).append("after_perform_block")
-          end
-          around_perform do |*_args|
-            class_variable_get(:@@block_result).append("around_perform_block")
           end
 
           def self.perform; end;
@@ -354,7 +335,7 @@ describe QueueClassicPlus::Base do
           subject.do
 
           expect(subject.class_variable_get(:@@block_result)).to eq(
-            %w(around_enqueue_block before_enqueue_block after_enqueue_block around_enqueue_block)
+            %w(before_enqueue_block after_enqueue_block)
           )
         end
       end
@@ -364,7 +345,7 @@ describe QueueClassicPlus::Base do
           subject.perform
 
           expect(subject.class_variable_get(:@@block_result)).to eq(
-            %w(around_perform_block before_perform_block after_perform_block around_perform_block)
+            %w(before_perform_block after_perform_block)
           )
         end
       end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -190,13 +190,13 @@ describe QueueClassicPlus::Base do
         Class.new(QueueClassicPlus::Base) do
           @queue = :test
 
-          qc_before_enqueue :before_enqueue_method
-          qc_after_enqueue :after_enqueue_method
-          qc_around_enqueue :around_enqueue_method
+          before_enqueue :before_enqueue_method
+          after_enqueue :after_enqueue_method
+          around_enqueue :around_enqueue_method
 
-          qc_before_perform :before_perform_method
-          qc_after_perform :after_perform_method
-          qc_around_perform :around_perform_method
+          before_perform :before_perform_method
+          after_perform :after_perform_method
+          around_perform :around_perform_method
 
           def self.before_enqueue_method(*_args); end;
           def self.after_enqueue_method(*_args); end;
@@ -269,23 +269,23 @@ describe QueueClassicPlus::Base do
           @queue = :test
           class_variable_set(:@@block_result, [])
 
-          qc_before_enqueue do |*_args|
+          before_enqueue do |*_args|
             class_variable_get(:@@block_result).append("before_enqueue_block")
           end
-          qc_after_enqueue do |*_args|
+          after_enqueue do |*_args|
             class_variable_get(:@@block_result).append("after_enqueue_block")
           end
-          qc_around_enqueue do |*_args|
+          around_enqueue do |*_args|
             class_variable_get(:@@block_result).append("around_enqueue_block")
           end
 
-          qc_before_perform do |*_args|
+          before_perform do |*_args|
             class_variable_get(:@@block_result).append("before_perform_block")
           end
-          qc_after_perform do |*_args|
+          after_perform do |*_args|
             class_variable_get(:@@block_result).append("after_perform_block")
           end
-          qc_around_perform do |*_args|
+          around_perform do |*_args|
             class_variable_get(:@@block_result).append("around_perform_block")
           end
 


### PR DESCRIPTION
* ~~Reverts to 4.0.0.alpha13 implementation. The `lock!` fixes were not working and this was the last stable version.~~
- [x] Will ship https://github.com/rainforestapp/queue_classic_plus/pull/61 first.
* Adds callbacks around `enqueue` and `perform` so we can modify behaviour from the calling app instead of making changes to QC.

Example of how these callbacks can be used: https://github.com/rainforestapp/Rainforest/pull/22392

The callbacks are implemented as wrappers around the original method which call class methods in the job before/after calling the original implementation.

Other approaches considered:

#### Make `QueueClassicPlus::Base` inherit from `ActiveJob` and use the equivalent `ActiveJob` callbacks

I tried this and it could work. However, `queue_classic_plus` uses a completely different implementation than `ActiveJob`. `ActiveJob::QueueAdapter` expects jobs to be instantiated and instance methods called for `perform`, `enqueue` etc. `queue_classic_plus` works by only calling class methods on the job. This would require some not so difficult but significant refactoring of `queue_classic_plus`, as well as refactoring of any of our existing jobs that would want to use these callbacks.

#### Use the `Observable` module

https://ruby-doc.org/stdlib-2.5.6/libdoc/observer/rdoc/Observable.html

This also works on instances. And since none of our jobs are instantiated, there is nowhere to add `observers`.