### PR TITLE
[RF-30293] Revert to 4.0.0.alpha13

### DIFF
--- a/lib/queue_classic_plus.rb
+++ b/lib/queue_classic_plus.rb
@@ -15,18 +15,14 @@ module QueueClassicPlus
 
   def self.migrate(c = QC::default_conn_adapter.connection)
     conn = QC::ConnAdapter.new(connection: c)
-    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS last_error TEXT")
-    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS remaining_retries INTEGER")
-    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN IF NOT EXISTS lock BOOLEAN NOT NULL DEFAULT FALSE")
-    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS index_queue_classic_jobs_enqueue_lock on queue_classic_jobs(q_name, method, args) WHERE lock IS TRUE")
+    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN last_error TEXT")
+    conn.execute("ALTER TABLE queue_classic_jobs ADD COLUMN remaining_retries INTEGER")
   end
 
   def self.demigrate(c = QC::default_conn_adapter.connection)
     conn = QC::ConnAdapter.new(connection: c)
-    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS last_error")
-    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS remaining_retries")
-    conn.execute("DROP INDEX IF EXISTS index_queue_classic_jobs_enqueue_lock")
-    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN IF EXISTS lock")
+    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN last_error")
+    conn.execute("ALTER TABLE queue_classic_jobs DROP COLUMN remaining_retries")
   end
 
   def self.exception_handler

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -2,16 +2,12 @@ module QueueClassicPlus
   class Base
     extend QueueClassicPlus::InheritableAttribute
 
-    # Max value for bigint calculated from
-    # https://stackoverflow.com/questions/28960478/postgres-maximum-value-for-bigint
-    PG_BIGINT_MAX = 9223372036854775807.freeze
-
     def self.queue
       QC::Queue.new(@queue)
     end
 
     def self.queue_name_digest
-      @queue_name_digest ||= @queue.to_s.to_i(36) % PG_BIGINT_MAX
+      @queue_name_digest ||= @queue.to_s.to_i(36)
     end
 
     inheritable_attr :locked

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -6,10 +6,6 @@ module QueueClassicPlus
       QC::Queue.new(@queue)
     end
 
-    def self.queue_name_digest
-      @queue_name_digest ||= @queue.to_s.to_i(36)
-    end
-
     inheritable_attr :locked
     inheritable_attr :skip_transaction
     inheritable_attr :retries_on
@@ -79,12 +75,8 @@ module QueueClassicPlus
     end
 
     def self.enqueue(method, *args)
-      conn = QC.default_conn_adapter.connection
-      conn.transaction do
-        conn.exec("SELECT pg_advisory_xact_lock(#{queue_name_digest})")
-        if can_enqueue?(method, *args)
-          queue.enqueue(method, *serialized(args))
-        end
+      if can_enqueue?(method, *args)
+        queue.enqueue(method, *serialized(args))
       end
     end
 

--- a/lib/queue_classic_plus/base.rb
+++ b/lib/queue_classic_plus/base.rb
@@ -2,8 +2,16 @@ module QueueClassicPlus
   class Base
     extend QueueClassicPlus::InheritableAttribute
 
+    # Max value for bigint calculated from
+    # https://stackoverflow.com/questions/28960478/postgres-maximum-value-for-bigint
+    PG_BIGINT_MAX = 9223372036854775807.freeze
+
     def self.queue
       QC::Queue.new(@queue)
+    end
+
+    def self.queue_name_digest
+      @queue_name_digest ||= @queue.to_s.to_i(36) % PG_BIGINT_MAX
     end
 
     inheritable_attr :locked
@@ -52,8 +60,42 @@ module QueueClassicPlus
       QueueClassicPlus.logger
     end
 
+    def self.can_enqueue?(method, *args)
+      if locked?
+        max_lock_time = ENV.fetch("QUEUE_CLASSIC_MAX_LOCK_TIME", 10 * 60).to_i
+
+        q = "SELECT COUNT(1) AS count
+             FROM
+               (
+                 SELECT 1
+                 FROM queue_classic_jobs
+                 WHERE q_name = $1 AND method = $2 AND args::text = $3::text
+                   AND (locked_at IS NULL OR locked_at > current_timestamp - interval '#{max_lock_time} seconds')
+                 LIMIT 1
+               )
+             AS x"
+
+        result = QC.default_conn_adapter.execute(q, @queue, method, JSON.dump(serialized(args)))
+        result['count'].to_i == 0
+      else
+        true
+      end
+    end
+
     def self.enqueue(method, *args)
-      queue.enqueue(method, *serialized(args), lock: locked?)
+       conn = QC.default_conn_adapter.connection
+       check_and_enqueue = proc do
+         conn.exec("SELECT pg_advisory_xact_lock(#{queue_name_digest})")
+         if can_enqueue?(method, *args)
+           queue.enqueue(method, *serialized(args))
+         end
+       end
+
+       if [PG::PQTRANS_ACTIVE, PG::PQTRANS_INTRANS].include?(conn.transaction_status)
+         check_and_enqueue.call
+       else
+         conn.transaction &check_and_enqueue
+       end
     end
 
     def self.enqueue_perform(*args)

--- a/lib/queue_classic_plus/queue_classic/queue.rb
+++ b/lib/queue_classic_plus/queue_classic/queue.rb
@@ -50,25 +50,5 @@ module QC
       end
     end
 
-    def enqueue(method, *args, lock: false)
-      QC.log_yield(:measure => 'queue.enqueue') do
-        insert_sql = <<-EOF
-          INSERT INTO #{QC.table_name} (q_name, method, args, lock)
-          VALUES ($1, $2, $3, $4)
-          ON CONFLICT (q_name, method, args) WHERE lock IS TRUE DO NOTHING
-          RETURNING id
-        EOF
-        begin
-          retries ||= 0
-          conn_adapter.execute(insert_sql, name, method, JSON.dump(args), lock)
-        rescue PG::Error => error
-          if (retries += 1) < 2
-            retry
-          else
-            raise
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha14'.freeze
+  VERSION = '4.0.0.alpha13'.freeze
 end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha13'.freeze
+  VERSION = '4.0.0.alpha18'.freeze
 end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha16'.freeze
+  VERSION = '4.0.0.alpha15'.freeze
 end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha15'.freeze
+  VERSION = '4.0.0.alpha14'.freeze
 end

--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha17'.freeze
+  VERSION = '4.0.0.alpha16'.freeze
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -44,23 +44,6 @@ describe QueueClassicPlus::Base do
       end
     end
 
-    context "when in a transaction" do
-      subject do
-        Class.new(QueueClassicPlus::Base) do
-          @queue = :test
-          lock!
-        end
-      end
-
-      it "does not create another transaction when enqueueing" do
-        conn = QC.default_conn_adapter.connection
-        expect(conn).to receive(:transaction).exactly(1).times.and_call_original
-        conn.transaction do
-          subject.do
-        end
-      end
-    end
-
     context "with default settings" do
       subject do
         Class.new(QueueClassicPlus::Base) do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -3,24 +3,6 @@ require 'active_record'
 
 describe QueueClassicPlus::Base do
   context "A child of QueueClassicPlus::Base" do
-    subject do
-      Class.new(QueueClassicPlus::Base) do
-        @queue = :test
-      end
-    end
-
-    it "allows multiple enqueues" do
-      threads = []
-      10.times do
-        threads << Thread.new do
-          subject.do
-        end
-      end
-      threads.each(&:join)
-
-      expect(subject).to have_queue_size_of(10)
-    end
-
     context "that is locked" do
       subject do
         Class.new(QueueClassicPlus::Base) do
@@ -31,27 +13,14 @@ describe QueueClassicPlus::Base do
 
       it "does not allow multiple enqueues" do
         threads = []
-        10.times do
+        50.times do
           threads << Thread.new do
             subject.do
             expect(subject).to have_queue_size_of(1)
           end
         end
-        threads.each(&:join)
-      end
 
-      it "allows enqueueing same job with different arguments" do
-        threads = []
-        (1..3).each do |arg|
-          10.times do
-            threads << Thread.new do
-              subject.do(arg)
-            end
-          end
-        end
         threads.each(&:join)
-
-        expect(subject).to have_queue_size_of(3)
       end
 
       it "checks for an existing job using the same serializing as job enqueuing" do
@@ -64,6 +33,14 @@ describe QueueClassicPlus::Base do
         subject.do(date)
         subject.do(date)
         expect(subject).to have_queue_size_of(1)
+      end
+
+      it "does allow multiple enqueues if something got locked for too long" do
+        subject.do
+        one_day_ago = Time.now - 60*60*24
+        execute "UPDATE queue_classic_jobs SET locked_at = '#{one_day_ago}' WHERE q_name = 'test'"
+        subject.do
+        expect(subject).to have_queue_size_of(2)
       end
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -12,15 +12,9 @@ describe QueueClassicPlus::Base do
       end
 
       it "does not allow multiple enqueues" do
-        threads = []
-        50.times do
-          threads << Thread.new do
-            subject.do
-            expect(subject).to have_queue_size_of(1)
-          end
-        end
-
-        threads.each(&:join)
+        subject.do
+        subject.do
+        expect(subject).to have_queue_size_of(1)
       end
 
       it "checks for an existing job using the same serializing as job enqueuing" do


### PR DESCRIPTION
Reverts the implementation to [4.0.0.alpha13](https://github.com/rainforestapp/queue_classic_plus/releases/tag/v4.0.0.alpha13) which is the last stable version.

Reverted one merge commit at a time to make sure everything reverted properly. Finally incremented the version number to `4.0.0.alpha18`.

Shipping this to ensure stability before adding features in https://github.com/rainforestapp/queue_classic_plus/pull/60.