### PR TITLE
[RF-31082] Fix memoization of failed job class in CustomWorker

### DIFF
--- a/lib/queue_classic_plus/version.rb
+++ b/lib/queue_classic_plus/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicPlus
-  VERSION = '4.0.0.alpha20'.freeze
+  VERSION = '4.0.0.alpha21'.freeze
 end

--- a/lib/queue_classic_plus/worker.rb
+++ b/lib/queue_classic_plus/worker.rb
@@ -24,6 +24,7 @@ module QueueClassicPlus
         force_retry = true
       end
 
+      @failed_job_class_memoized = false
       @failed_job = job
       @raw_args = job[:args]
 


### PR DESCRIPTION
The same CustomWorker instance is used to handle multiple failures, which leads to the wrong job classes being enqueued for retries when subsequent failures are for different job classes.